### PR TITLE
Restore missing Go internal/config package to fix pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ docs/_build/
 *_BL.md
 *_ARCH.md
 .task/
+
+!internal/config/
+!internal/config/*.go

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBridgeAddr      = ":8080"
+	defaultHTTPTimeoutMS   = 2000
+	defaultPostgresSSLMode = "disable"
+)
+
+type Config struct {
+	PostgresURL  string
+	BridgeAddr   string
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	IdleTimeout  time.Duration
+}
+
+func Load() (Config, error) {
+	rawPostgresURL := strings.TrimSpace(os.Getenv("ps_url"))
+	if rawPostgresURL == "" {
+		return Config{}, fmt.Errorf("ps_url is required")
+	}
+
+	postgresURL, err := NormalizePostgresURL(rawPostgresURL)
+	if err != nil {
+		return Config{}, err
+	}
+
+	timeoutMS, err := envInt("GO_BRIDGE_HTTP_TIMEOUT_MS", defaultHTTPTimeoutMS)
+	if err != nil {
+		return Config{}, err
+	}
+
+	addr := strings.TrimSpace(os.Getenv("GO_BRIDGE_HTTP_ADDR"))
+	if addr == "" {
+		addr = defaultBridgeAddr
+	}
+
+	timeout := time.Duration(timeoutMS) * time.Millisecond
+	return Config{
+		PostgresURL:  postgresURL,
+		BridgeAddr:   addr,
+		ReadTimeout:  timeout,
+		WriteTimeout: timeout,
+		IdleTimeout:  timeout,
+	}, nil
+}
+
+func NormalizePostgresURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("postgres url is required")
+	}
+
+	normalized := strings.Replace(raw, "postgresql+psycopg://", "postgres://", 1)
+	normalized = strings.Replace(normalized, "postgresql://", "postgres://", 1)
+
+	u, err := url.Parse(normalized)
+	if err != nil {
+		return "", fmt.Errorf("parse postgres url: %w", err)
+	}
+	if u.Scheme != "postgres" {
+		return "", fmt.Errorf("unsupported postgres url scheme %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("postgres url host is required")
+	}
+	if strings.TrimPrefix(u.Path, "/") == "" {
+		return "", fmt.Errorf("postgres url database name is required")
+	}
+
+	query := u.Query()
+	if query.Get("sslmode") == "" {
+		query.Set("sslmode", defaultPostgresSSLMode)
+		u.RawQuery = query.Encode()
+	}
+
+	return u.String(), nil
+}
+
+func envInt(name string, defaultValue int) (int, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return defaultValue, nil
+	}
+
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be an integer: %w", name, err)
+	}
+	if value <= 0 {
+		return 0, fmt.Errorf("%s must be > 0", name)
+	}
+
+	return value, nil
+}


### PR DESCRIPTION
### Motivation
- CI and local `go test` failed because multiple Go packages import `github.com/vlle/Photoshnaya/internal/config` but the package was missing from the repo, causing build/setup errors. 
- The `.gitignore` contained a broad `*config*` pattern which silently ignored the newly added package files, preventing them from being tracked.

### Description
- Add `internal/config/config.go` providing `Config` type and `Load()` to read bridge runtime settings from environment variables with sensible defaults. 
- Implement `NormalizePostgresURL()` to accept existing DSN formats (including `postgresql+psycopg://` and `postgresql://`), validate components and enforce a default `sslmode`.
- Add `envInt()` helper to parse integer env vars for HTTP timeout configuration and wire timeouts into `Config`. 
- Update `.gitignore` to explicitly allow tracking `internal/config/` and `internal/config/*.go` so the package is not ignored by the existing wildcard rules.

### Testing
- Ran `go test ./...` which completed successfully and reported packages OK or cached; integration package executed as cached `ok`.
- Verified `go test ./internal/config` reports no test files and the package compiles as imported by other packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e38816ef8832b818e2547c33dae57)