### PR TITLE
Fix CI build on Python 3.10 by adding TOML compatibility

### DIFF
--- a/app/handlers/internal_logic/vote_start.py
+++ b/app/handlers/internal_logic/vote_start.py
@@ -1,5 +1,10 @@
 import pathlib
-import tomllib
+import sys
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from services.vote_backend import VoteBackend, VoteBackendBusinessError
 from utils.TelegramUserClass import TelegramChat, TelegramUser

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ ruff==0.0.262
 six==1.16.0
 SQLAlchemy==2.0.4
 typing_extensions==4.5.0
+tomli==2.0.1; python_version < "3.11"
 tzdata==2023.3
 vine==5.0.0
 virtualenv==20.23.1


### PR DESCRIPTION
### Motivation
- The CI environment runs on Python 3.10 where the stdlib `tomllib` is not available, which caused test collection to fail with `ModuleNotFoundError: No module named 'tomllib'`.
- Make TOML parsing work across Python 3.10 and 3.11+ so tests can be collected and run in the existing CI matrix.

### Description
- Add a version-gated import in `app/handlers/internal_logic/vote_start.py` to `import tomllib` on Python >= 3.11 and `import tomli as tomllib` on older Pythons. (`app/handlers/internal_logic/vote_start.py`)
- Add an explicit conditional dependency `tomli==2.0.1; python_version < "3.11"` to `requirements.txt` so Python 3.10 CI runners install the TOML parser. (`requirements.txt`)

### Testing
- Ran `cd app && pytest tests/test_vote_start.py -v` and the file-specific suite passed: `5 passed, 1 warning`.
- Ran the full app test collection with `cd app && pytest tests -v`, which completed but produced unrelated DB/session errors (2 failed, 12 passed, 31 errors) stemming from the test database/session binding in this environment and not from the TOML import change.
- Attempted to run the docker-based CI step (`docker compose -f docker-compose.test.yml up`), but the runner environment does not have `docker` available so that check was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba61cd45f8832b90f77022f4419d6d)